### PR TITLE
09 core view a separate page for each topic with a list of related articles

### DIFF
--- a/src/components/ArticleShowCard.jsx
+++ b/src/components/ArticleShowCard.jsx
@@ -1,10 +1,11 @@
 import React from 'react'
 
-function ArticleShowCard({data}) {
+function ArticleShowCard({filteredCategoryData}) {
 
-    const articleListInfo = data.map((article)=> {
+    const articleListInfo = filteredCategoryData.map((article)=> {
         const {article_id, title, author, created_at, topic, article_img_url, votes, comment_count} = article
         const hrefArticle = "/articles/" + article_id
+        const hrefCategory = "/articles?topic="+ topic
         // const hrefArticleComments = hrefArticle + "#article_comments"
 
         return (<section className="articleCard" key={article_id}>
@@ -15,7 +16,7 @@ function ArticleShowCard({data}) {
         <div className='articleCard-body'>
         <p>Author: <a href="#">{author}</a> | Posted: {created_at.substring(0,10)} </p>
         <p>Votes: {votes} | Comments: <a href={hrefArticle}>{comment_count}</a></p>
-        <p>Category: <a href="#">{topic}</a></p>
+        <p>Category: <a href={hrefCategory}>{topic}</a></p>
         </div>
         <div className='articleCard-footer'></div>
         </section>

--- a/src/components/Articles.jsx
+++ b/src/components/Articles.jsx
@@ -28,8 +28,6 @@ function Articles() {
     ? data.filter(article => article.topic === queryCategory)
     : data
 
-    console.log(filteredCategoryData, "filtered data")
-
 /* next iteration of page 
    Author link will re-render current Articles component with filtered list of articles in queried author
 */

--- a/src/components/Articles.jsx
+++ b/src/components/Articles.jsx
@@ -2,10 +2,14 @@ import React from 'react'
 import { useState, useEffect } from 'react'
 import { getArticles } from '../api'
 import ArticleShowCard from './ArticleShowCard'
+import { useSearchParams } from 'react-router-dom'
 
 function Articles() {
     const [isLoading, setIsLoading] = useState(true)
     const [data, setData] = useState([])
+    const [searchParams, setSearchParams] = useSearchParams()
+
+    const queryCategory = searchParams.get("topic")
 
     useEffect(()=>{
         getArticles()
@@ -20,8 +24,13 @@ function Articles() {
     
     if (isLoading) return <p>Loading...</p>
 
+    const filteredCategoryData = queryCategory
+    ? data.filter(article => article.topic === queryCategory)
+    : data
+
+    console.log(filteredCategoryData, "filtered data")
+
 /* next iteration of page 
-   Category link will re-render current Articles component with filtered list of articles in queried category
    Author link will re-render current Articles component with filtered list of articles in queried author
 */
 
@@ -30,7 +39,7 @@ function Articles() {
         <section className="main-articleList">
             <p>Here is the list of the articles</p>
                 <div id="articleList">
-                <ArticleShowCard data={data}/>
+                <ArticleShowCard filteredCategoryData={filteredCategoryData}/>
                 </div>
         </section>
     </>

--- a/src/components/Topics.jsx
+++ b/src/components/Topics.jsx
@@ -22,7 +22,7 @@ import { getTopics } from '../api'
     const queryTopicHref = "/articles?topic="+topic.slug
     return (
       <div key={topic.slug}>
-        <p>{topic.slug} -> {topic.description}</p>
+        <p><a href={queryTopicHref}>{topic.slug}</a>: {topic.description}</p>
       </div>
     )
   })


### PR DESCRIPTION
This pull request establishes the following:

- creates a filtering behaviour in the Articles component *
- uses the useSearchParams to obtain the filter term from the URL and then able the filter to the returned data from the API
- lists the available topics with related description in the Topics component via a fetch request to the API
- adds a link via the topic term that creates a URL to be processed on the Articles component as stated previously
- adds a link on the ArticleShowCard that allows the user to return a list of articles in that category when clicked

*please not this is a work around as I have not completed BE ticket 11.